### PR TITLE
Reset to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-jwks",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Fetch utils for JWKS keys",
   "main": "src/get-jwks.js",
   "engines": {
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nearform/get-jwks.git"
+    "url": "git+https://github.com/nearform/get-jwks.git"
   },
   "keywords": [
     "jwks",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-jwks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Fetch utils for JWKS keys",
   "main": "src/get-jwks.js",
   "engines": {


### PR DESCRIPTION
Currently the version on npm is 1.0.1, this will reset to 2.0.0 so that the next npm released as a patch will be to 2.0.1