### PR TITLE
feat: enable provider discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ const getJwks = buildGetJwks({
 - `max`: Max items to hold in cache. Defaults to 100.
 - `maxAge`: Milliseconds an item will remain in cache. Defaults to 60s.
 - `allowedDomains`: Array of allowed domains. By default all domains are allowed.
-- `providerDiscovery`: Flag if domain is used as issuer and Provider Discovery is done as described here [OpenID Provider Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig). From the .well-known endpoint the jwks_uri retreival uri can be extracted [Provider Metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata). In the token this is the `iss` property. Defaults to false
+- `providerDiscovery`: Indicates if the Provider Configuration Information is used to automatically get the jwks_uri from the [OpenID Provider Discovery Endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig). This endpoint is exposing the [Provider Metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata). With this flag set to true the domain will be treated as the OpenID Issuer which is the iss property in the token. Defaults to false
 
 > `max` and `maxAge` are provided to [lru-cache](https://www.npmjs.com/package/lru-cache).
 
@@ -48,7 +48,7 @@ const jwk = await getJwks.getJwk({
 
 Calling the asynchronous function `getJwk` will fetch the [JSON Web Key](https://tools.ietf.org/html/rfc7517), and verify if any of the public keys matches the provided `alg` and `kid` values. It will cache the matching key so if called again it will not make another request to retrieve a JWKS. It will also use a cache to store stale values which is used in case of errors as a fallback mechanism.
 
-- `domain`: A string containing the domain (e.g. `https://www.example.com/`, with or without trailing slash) from which the library should fetch the JWKS. If providerDiscovery Flag is false `get-jwks` will add the JWKS location (`.well-known/jwks.json`) to form the final url (ie: `https://www.example.com/.well-known/jwks.json`) otherwise the domain will be treated as issuer and the retrival will be done via PRovider Discovery Endpoint.
+- `domain`: A string containing the domain (e.g. `https://www.example.com/`, with or without trailing slash) from which the library should fetch the JWKS. If providerDiscovery flag is set to false `get-jwks` will add the JWKS location (`.well-known/jwks.json`) to form the final url (ie: `https://www.example.com/.well-known/jwks.json`) otherwise the domain will be treated as tthe openid issuer and the retrival will be done via the Provider Discovery Endpoint.
 - `alg`: The alg header parameter represents the cryptographic algorithm used to secure the token. You will find it in your decoded JWT.
 - `kid`: The kid is a hint that indicates which key was used to secure the JSON web signature of the token. You will find it in your decoded JWT.
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ const getJwks = buildGetJwks({
   max: 100,
   maxAge: 60 * 1000,
   allowedDomains: ['https://example.com'],
+  providerDiscovery: false,
 })
 ```
 
 - `max`: Max items to hold in cache. Defaults to 100.
 - `maxAge`: Milliseconds an item will remain in cache. Defaults to 60s.
 - `allowedDomains`: Array of allowed domains. By default all domains are allowed.
+- `providerDiscovery`: Flag if domain is used as issuer and Provider Discovery is done as described here [OpenID Provider Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig). From the .well-known endpoint the jwks_uri retreival uri can be extracted [Provider Metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata). In the token this is the `iss` property. Defaults to false
 
 > `max` and `maxAge` are provided to [lru-cache](https://www.npmjs.com/package/lru-cache).
 
@@ -46,7 +48,7 @@ const jwk = await getJwks.getJwk({
 
 Calling the asynchronous function `getJwk` will fetch the [JSON Web Key](https://tools.ietf.org/html/rfc7517), and verify if any of the public keys matches the provided `alg` and `kid` values. It will cache the matching key so if called again it will not make another request to retrieve a JWKS. It will also use a cache to store stale values which is used in case of errors as a fallback mechanism.
 
-- `domain`: A string containing the domain (e.g. `https://www.example.com/`, with or without trailing slash) from which the library should fetch the JWKS. `get-jwks` will add the JWKS location (`.well-known/jwks.json`) to form the final url (ie: `https://www.example.com/.well-known/jwks.json`).
+- `domain`: A string containing the domain (e.g. `https://www.example.com/`, with or without trailing slash) from which the library should fetch the JWKS. If providerDiscovery Flag is false `get-jwks` will add the JWKS location (`.well-known/jwks.json`) to form the final url (ie: `https://www.example.com/.well-known/jwks.json`) otherwise the domain will be treated as issuer and the retrival will be done via PRovider Discovery Endpoint.
 - `alg`: The alg header parameter represents the cryptographic algorithm used to secure the token. You will find it in your decoded JWT.
 - `kid`: The kid is a hint that indicates which key was used to secure the JSON web signature of the token. You will find it in your decoded JWT.
 

--- a/test/constants.js
+++ b/test/constants.js
@@ -35,8 +35,13 @@ const token = jwt.sign({ name: 'Jane Doe' }, privateKey, {
   issuer: domain,
   keyid: jwk.kid,
 })
+const oidcConfig = {
+  issuer: 'https://localhost/',
+  jwks_uri: 'https://localhost/.well-known/certs',
+}
 
 module.exports = {
+  oidcConfig,
   domain,
   token,
   jwks,

--- a/test/fastify-jwt-integrations.spec.js
+++ b/test/fastify-jwt-integrations.spec.js
@@ -5,7 +5,7 @@ const nock = require('nock')
 const Fastify = require('fastify')
 const fjwt = require('fastify-jwt')
 
-const { jwks, token, domain } = require('./constants')
+const { oidcConfig, jwks, token, domain } = require('./constants')
 const buildGetJwks = require('../src/get-jwks')
 
 t.beforeEach(async () => {
@@ -36,6 +36,49 @@ t.test('fastify-jwt integration tests', async t => {
     },
   })
 
+  fastify.addHook('onRequest', async request => {
+    await request.jwtVerify()
+  })
+
+  fastify.get('/', async request => {
+    return request.user.name
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+  })
+
+  t.strictEqual(response.statusCode, 200)
+  t.strictEqual(response.body, 'Jane Doe')
+  t.done()
+})
+
+t.test('fastify-jwt integration tests with providerDiscovery', async t => {
+  nock(domain)
+    .get('/.well-known/openid-configuration')
+    .once()
+    .reply(200, oidcConfig)
+  nock(domain).get('/.well-known/certs').reply(200, jwks)
+
+  const fastify = Fastify()
+  const getJwks = buildGetJwks({ providerDiscovery: true })
+
+  fastify.register(fjwt, {
+    decode: { complete: true },
+    secret: (request, token, callback) => {
+      const {
+        header: { kid, alg },
+        payload: { iss },
+      } = token
+      getJwks
+        .getPublicKey({ kid, domain: iss, alg })
+        .then(publicKey => callback(null, publicKey), callback)
+    },
+  })
   fastify.addHook('onRequest', async request => {
     await request.jwtVerify()
   })

--- a/test/getJwkDiscovery.spec.js
+++ b/test/getJwkDiscovery.spec.js
@@ -1,0 +1,278 @@
+'use strict'
+
+const nock = require('nock')
+const t = require('tap')
+
+const { oidcConfig, jwks, domain } = require('./constants')
+const buildGetJwks = require('../src/get-jwks')
+
+t.beforeEach(async () => {
+  nock.disableNetConnect()
+})
+
+t.afterEach(async () => {
+  nock.cleanAll()
+  nock.enableNetConnect()
+})
+
+t.test('rejects if the discovery request fails', async t => {
+  nock(domain)
+    .get('/.well-known/openid-configuration')
+    .reply(500, { msg: 'baam' })
+
+  const [{ alg, kid }] = jwks.keys
+  const getJwks = buildGetJwks({ providerDiscovery: true })
+
+  const expectedError = new Error('Internal Server Error')
+  expectedError.body = { msg: 'baam' }
+
+  await t.rejects(getJwks.getJwk({ domain, alg, kid }), expectedError)
+})
+
+t.test('rejects if the request fails', async t => {
+  nock(domain).get('/.well-known/openid-configuration').reply(200, oidcConfig)
+  nock(domain).get('/.well-known/certs').reply(500, { msg: 'boom' })
+
+  const [{ alg, kid }] = jwks.keys
+  const getJwks = buildGetJwks({ providerDiscovery: true })
+
+  const expectedError = new Error('Internal Server Error')
+  expectedError.body = { msg: 'boom' }
+
+  await t.rejects(getJwks.getJwk({ domain, alg, kid }), expectedError)
+})
+
+t.test('returns a jwk if alg and kid match for discovery', async t => {
+  nock(domain).get('/.well-known/openid-configuration').reply(200, oidcConfig)
+  nock(domain).get('/.well-known/certs').reply(200, jwks)
+  const getJwks = buildGetJwks({ providerDiscovery: true })
+  const key = jwks.keys[0]
+
+  const jwk = await getJwks.getJwk({ domain, alg: key.alg, kid: key.kid })
+
+  t.ok(jwk)
+  t.deepEqual(jwk, key)
+})
+
+t.test('caches a successful response for discovery', async t => {
+  nock(domain).get('/.well-known/openid-configuration').reply(200, oidcConfig)
+  nock(domain).get('/.well-known/certs').reply(200, jwks)
+
+  const getJwks = buildGetJwks({ providerDiscovery: true })
+  const key = jwks.keys[0]
+  const { alg, kid } = key
+
+  await getJwks.getJwk({ domain, alg, kid })
+  const jwk = await getJwks.getJwk({ domain, alg, kid })
+
+  t.ok(jwk)
+  t.deepEqual(jwk, key)
+})
+
+t.test('does not cache a failed response for discovery', async t => {
+  nock(domain)
+    .get('/.well-known/openid-configuration')
+    .twice()
+    .reply(200, oidcConfig)
+  nock(domain).get('/.well-known/certs').reply(500, { msg: 'boom' })
+  nock(domain).get('/.well-known/certs').reply(200, jwks)
+
+  const [{ alg, kid }] = jwks.keys
+  const getJwks = buildGetJwks({ providerDiscovery: true })
+
+  await t.rejects(getJwks.getJwk({ domain, alg, kid }))
+  await t.resolves(getJwks.getJwk({ domain, alg, kid }))
+})
+
+t.test('rejects if response is an empty object for discovery', async t => {
+  nock(domain).get('/.well-known/openid-configuration').reply(200, oidcConfig)
+  nock(domain).get('/.well-known/certs').reply(200, {})
+  const getJwks = buildGetJwks({ providerDiscovery: true })
+  const [{ alg, kid }] = jwks.keys
+
+  return t.rejects(
+    getJwks.getJwk({ domain, alg, kid }),
+    'No JWKS found in the response.'
+  )
+})
+
+t.test('rejects if no JWKS are found in the response', async t => {
+  nock(domain).get('/.well-known/openid-configuration').reply(200, oidcConfig)
+  nock(domain).get('/.well-known/certs').reply(200, { keys: [] })
+  const getJwks = buildGetJwks({ providerDiscovery: true })
+  const [{ alg, kid }] = jwks.keys
+
+  return t.rejects(
+    getJwks.getJwk({ domain, alg, kid }),
+    'No JWKS found in the response.'
+  )
+})
+
+t.test('supports domain without trailing slash for discovery', async t => {
+  nock(domain)
+    .get('/.well-known/openid-configuration')
+    .once()
+    .reply(200, oidcConfig)
+  nock(domain).get('/.well-known/certs').reply(200, jwks)
+  const getJwks = buildGetJwks({ providerDiscovery: true })
+  const [{ alg, kid }] = jwks.keys
+
+  const key = await getJwks.getJwk({ domain: 'https://localhost', alg, kid })
+  t.ok(key)
+})
+
+t.test('does not execute concurrent requests for discovery', () => {
+  nock(domain)
+    .get('/.well-known/openid-configuration')
+    .once()
+    .reply(200, oidcConfig)
+  nock(domain).get('/.well-known/certs').once().reply(200, jwks)
+
+  const getJwks = buildGetJwks({ providerDiscovery: true })
+  const [{ alg, kid }] = jwks.keys
+
+  return Promise.all([
+    getJwks.getJwk({ domain, alg, kid }),
+    getJwks.getJwk({ domain, alg, kid }),
+  ])
+})
+
+t.test(
+  'returns a stale cached value if request fails for discovery',
+  async t => {
+    // allow 2 requests, third will throw an error
+    nock(domain)
+      .get('/.well-known/openid-configuration')
+      .thrice()
+      .reply(200, oidcConfig)
+    nock(domain).get('/.well-known/certs').twice().reply(200, jwks)
+    nock(domain).get('/.well-known/certs').once().reply(500, { boom: true })
+
+    // allow only 1 entry in cache
+    const getJwks = buildGetJwks({ providerDiscovery: true, max: 1 })
+    const [key1, key2] = jwks.keys
+
+    // request key1
+    await getJwks.getJwk({
+      domain: 'https://localhost',
+      alg: key1.alg,
+      kid: key1.kid,
+    })
+
+    // request key2
+    await getJwks.getJwk({
+      domain: 'https://localhost',
+      alg: key2.alg,
+      kid: key2.kid,
+    })
+
+    // now key1 is stale
+    // request key1
+    const key = await getJwks.getJwk({
+      domain: 'https://localhost',
+      alg: key1.alg,
+      kid: key1.kid,
+    })
+
+    t.sameStrict(key, key1)
+  }
+)
+
+t.test('allowed domains for discovery', async t => {
+  t.test('allows any domain by default for discovery ', async t => {
+    const domain = 'https://example.com'
+
+    nock(domain)
+      .get('/.well-known/openid-configuration')
+      .reply(200, {
+        issuer: domain,
+        jwks_uri: `${domain}/.well-known/certs`,
+      })
+    nock(domain).get('/.well-known/certs').reply(200, jwks)
+    const getJwks = buildGetJwks({ providerDiscovery: true })
+
+    const [{ alg, kid }] = jwks.keys
+
+    t.ok(await getJwks.getJwk({ domain, alg, kid }))
+  })
+
+  const allowedCombinations = [
+    // same without trailing slash
+    ['https://example.com', 'https://example.com'],
+    // same with trailing slash
+    ['https://example.com/', 'https://example.com/'],
+    // one without, one with
+    ['https://example.com', 'https://example.com/'],
+    // one with, one without
+    ['https://example.com/', 'https://example.com'],
+  ]
+
+  allowedCombinations.forEach(([allowedDomain, domainFromToken]) => {
+    t.test(
+      `allows domain ${allowedDomain} requested with ${domainFromToken} for discovery`,
+      async t => {
+        const allowedDomainSlash = allowedDomain.endsWith('/')
+          ? allowedDomain
+          : `${allowedDomain}/`
+        nock(allowedDomain)
+          .get('/.well-known/openid-configuration')
+          .reply(200, {
+            issuer: allowedDomain,
+            jwks_uri: `${allowedDomainSlash}.well-known/certs`,
+          })
+        nock(allowedDomain).get('/.well-known/certs').reply(200, jwks)
+        const getJwks = buildGetJwks({
+          providerDiscovery: true,
+          allowedDomains: [allowedDomain],
+        })
+
+        const [{ alg, kid }] = jwks.keys
+
+        t.ok(await getJwks.getJwk({ domain: domainFromToken, alg, kid }))
+      }
+    )
+  })
+
+  t.test('allows multiple domains for discovery', async t => {
+    const domain1 = 'https://example1.com'
+    const domain2 = 'https://example2.com'
+    nock(domain1)
+      .get('/.well-known/openid-configuration')
+      .reply(200, {
+        issuer: domain,
+        jwks_uri: `${domain1}/.well-known/certs`,
+      })
+    nock(domain1).get('/.well-known/certs').reply(200, jwks)
+    nock(domain2)
+      .get('/.well-known/openid-configuration')
+      .reply(200, {
+        issuer: domain,
+        jwks_uri: `${domain2}/.well-known/certs`,
+      })
+    nock(domain2).get('/.well-known/certs').reply(200, jwks)
+
+    const getJwks = buildGetJwks({
+      providerDiscovery: true,
+      allowedDomains: [domain1, domain2],
+    })
+
+    const [{ alg, kid }] = jwks.keys
+
+    t.ok(await getJwks.getJwk({ domain: domain1, alg, kid }))
+    t.ok(await getJwks.getJwk({ domain: domain2, alg, kid }))
+  })
+
+  t.test('forbids domain outside of the allow list', async t => {
+    const getJwks = buildGetJwks({
+      providerDiscovery: true,
+      allowedDomains: ['https://example.com/'],
+    })
+
+    const [{ alg, kid }] = jwks.keys
+
+    return t.rejects(
+      getJwks.getJwk({ domain, alg, kid }),
+      'The domain is not allowed.'
+    )
+  })
+})

--- a/test/getJwksUri.spec.js
+++ b/test/getJwksUri.spec.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const t = require('tap')
+const nock = require('nock')
+
+const { domain } = require('./constants')
+
+const buildGetJwks = require('../src/get-jwks')
+
+t.beforeEach(async () => {
+  nock.disableNetConnect()
+})
+
+t.afterEach(async () => {
+  nock.cleanAll()
+  nock.enableNetConnect()
+})
+
+t.test('throw error if the discovery request fails', async t => {
+  nock(domain)
+    .get('/.well-known/openid-configuration')
+    .reply(500, { msg: 'baam' })
+  const getJwks = buildGetJwks({ providerDiscovery: true })
+
+  const expectedError = new Error('Internal Server Error')
+
+  await t.rejects(getJwks.getJwksUri(domain), expectedError)
+})
+
+t.test(
+  'throw error if the discovery request has no jwks_uri property',
+  async t => {
+    nock(domain)
+      .get('/.well-known/openid-configuration')
+      .reply(200, { msg: 'baam' })
+    const getJwks = buildGetJwks({ providerDiscovery: true })
+
+    const expectedError = new Error(
+      'No valid jwks_uri key found in providerConfig'
+    )
+
+    await t.rejects(getJwks.getJwksUri(domain), expectedError)
+  }
+)

--- a/test/getPublicKeyDiscovery.spec.js
+++ b/test/getPublicKeyDiscovery.spec.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const t = require('tap')
+const jwkToPem = require('jwk-to-pem')
+const sinon = require('sinon')
+
+const { jwks } = require('./constants')
+const buildGetJwks = require('../src/get-jwks')
+
+t.test(
+  'it provides the result of getJwk to jwkToPem for discovery',
+  async t => {
+    const getJwks = buildGetJwks({ providerDiscovery: true })
+
+    const [jwk] = jwks.keys
+
+    const getJwkStub = sinon.stub(getJwks, 'getJwk').resolves(jwk)
+
+    const signature = 'whatever'
+
+    const pem = await getJwks.getPublicKey(signature)
+
+    t.equal(pem, jwkToPem(jwk))
+    sinon.assert.calledOnceWithExactly(getJwkStub, signature)
+  }
+)
+
+t.test('it rejects if getJwk rejects for discovery', t => {
+  const getJwks = buildGetJwks({ providerDiscovery: true })
+
+  sinon.stub(getJwks, 'getJwk').rejects(new Error('boom'))
+
+  return t.rejects(getJwks.getPublicKey('whatever'), 'boom')
+})


### PR DESCRIPTION
This PR enables the use of the Provider Discovery Endpoints  which is described here https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig.

When the Provider Discovery Enpoint is present it must contain an "jwks_uri" property which we can then use to get the url where we can get the jwks from.

This feature is enabled by a proverConfig flag in the initialization of the module.