### PR TITLE
feat: handle optional alg parameter for keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ const jwk = await getJwks.getJwk({
 })
 ```
 
-Calling the asynchronous function `getJwk` will fetch the [JSON Web Key](https://tools.ietf.org/html/rfc7517), and verify if any of the public keys matches the provided `alg` and `kid` values. It will cache the matching key so if called again it will not make another request to retrieve a JWKS. It will also use a cache to store stale values which is used in case of errors as a fallback mechanism.
+Calling the asynchronous function `getJwk` will fetch the [JSON Web Key](https://tools.ietf.org/html/rfc7517), and verify if any of the public keys matches the provided `alg` (if any) and `kid` values. It will cache the matching key so if called again it will not make another request to retrieve a JWKS. It will also use a cache to store stale values which is used in case of errors as a fallback mechanism.
 
 - `domain`: A string containing the domain (e.g. `https://www.example.com/`, with or without trailing slash) from which the library should fetch the JWKS. If providerDiscovery flag is set to false `get-jwks` will add the JWKS location (`.well-known/jwks.json`) to form the final url (ie: `https://www.example.com/.well-known/jwks.json`) otherwise the domain will be treated as tthe openid issuer and the retrival will be done via the Provider Discovery Endpoint.
-- `alg`: The alg header parameter represents the cryptographic algorithm used to secure the token. You will find it in your decoded JWT.
+- `alg`: The alg header parameter is an optional parameter that represents the cryptographic algorithm used to secure the token. You will find it in your decoded JWT.
 - `kid`: The kid is a hint that indicates which key was used to secure the JSON web signature of the token. You will find it in your decoded JWT.
 
 ### getPublicKey

--- a/src/get-jwks.js
+++ b/src/get-jwks.js
@@ -109,7 +109,7 @@ function buildGetJwks(options = {}) {
       throw new Error(errors.NO_JWKS)
     }
 
-    const jwk = body.keys.find(key => key.alg === alg && key.kid === kid)
+    const jwk = body.keys.find(key => (key.alg === undefined || key.alg === alg) && key.kid === kid)
 
     if (!jwk) {
       throw new Error(errors.JWK_NOT_FOUND)

--- a/test/constants.js
+++ b/test/constants.js
@@ -38,12 +38,8 @@ const jwks = {
 }
 const privateKey = readFileSync(path.join(__dirname, 'private.pem'), 'utf8')
 const jwk = jwks.keys[1]
-let defaultSigningAlgorithm;
-if (jwk.alg === undefined && jwk.kty === 'RSA') {
-  defaultSigningAlgorithm = 'RS256';
-}
 const token = jwt.sign({ name: 'Jane Doe' }, privateKey, {
-  algorithm: jwk.alg || defaultSigningAlgorithm,
+  algorithm: jwk.alg,
   issuer: domain,
   keyid: jwk.kid,
 })

--- a/test/constants.js
+++ b/test/constants.js
@@ -52,8 +52,6 @@ const oidcConfig = {
   jwks_uri: 'https://localhost/.well-known/certs',
 }
 
-console.log(jwks)
-
 module.exports = {
   oidcConfig,
   domain,

--- a/test/constants.js
+++ b/test/constants.js
@@ -38,11 +38,12 @@ const jwks = {
 }
 const privateKey = readFileSync(path.join(__dirname, 'private.pem'), 'utf8')
 const jwk = jwks.keys[1]
+let defaultSigningAlgorithm;
 if (jwk.alg === undefined && jwk.kty === 'RSA') {
-  jwk.alg = 'RS256';
+  defaultSigningAlgorithm = 'RS256';
 }
 const token = jwt.sign({ name: 'Jane Doe' }, privateKey, {
-  algorithm: jwk.alg,
+  algorithm: jwk.alg || defaultSigningAlgorithm,
   issuer: domain,
   keyid: jwk.kid,
 })
@@ -50,6 +51,8 @@ const oidcConfig = {
   issuer: 'https://localhost/',
   jwks_uri: 'https://localhost/.well-known/certs',
 }
+
+console.log(jwks)
 
 module.exports = {
   oidcConfig,

--- a/test/constants.js
+++ b/test/constants.js
@@ -26,10 +26,21 @@ const jwks = {
         '7KRDtHuJ9-R1cYzB9-E4TUVazzv93MMmMo_38nOwEKNxlWs7OVg397d0SCsdmBbcbr4KTMeblY4a-VOzLVZ5ycYgi7ZbMvv7RzunKuPsjm7m863dLnPUFOptsFVANDOHgDYopKBFYoIMoxjXU7bOzLL-Ez0oO5keT1hGZkJT_7GRvKyYigugN4lLia4Tb3AmUN60wiloyQCJ2xYATWHB0e4sTwIDq6MFXhVFHXV6ZBU7sDh0HqmP08gJtMnsFOE7zUcbpqTvpz5nAR6EyUs7R0g61WmGUfQTrE6byVCZ8w0NN4Xer6IQBjnDZWbmf69jsAFFAYDCe-omWXY526qLQw',
       use: 'sig',
     },
+    {
+      kid: 'KEY_2',
+      e: 'AQAB',
+      kty: 'RSA',
+      n:
+        '7KRDtHuJ9-R1cYzB9-E4TUVazzv93MMmMo_38nOwEKNxlWs7OVg397d0SCsdmBbcbr4KTMeblY4a-VOzLVZ5ycYgi7ZbMvv7RzunKuPsjm7m863dLnPUFOptsFVANDOHgDYopKBFYoIMoxjXU7bOzLL-Ez0oO5keT1hGZkJT_7GRvKyYigugN4lLia4Tb3AmUN60wiloyQCJ2xYATWHB0e4sTwIDq6MFXhVFHXV6ZBU7sDh0HqmP08gJtMnsFOE7zUcbpqTvpz5nAR6EyUs7R0g61WmGUfQTrE6byVCZ8w0NN4Xer6IQBjnDZWbmf69jsAFFAYDCe-omWXY526qLQw',
+      use: 'sig'
+    }
   ],
 }
 const privateKey = readFileSync(path.join(__dirname, 'private.pem'), 'utf8')
 const jwk = jwks.keys[1]
+if (jwk.alg === undefined && jwk.kty === 'RSA') {
+  jwk.alg = 'RS256';
+}
 const token = jwt.sign({ name: 'Jane Doe' }, privateKey, {
   algorithm: jwk.alg,
   issuer: domain,

--- a/test/getJwk.spec.js
+++ b/test/getJwk.spec.js
@@ -49,6 +49,17 @@ t.test('returns a jwk if alg and kid match', async t => {
   t.deepEqual(jwk, key)
 })
 
+t.test('returns a jwk if no alg is provided and kid match', async t => {
+  nock(domain).get('/.well-known/jwks.json').reply(200, jwks)
+  const getJwks = buildGetJwks()
+  const key = jwks.keys[2]
+
+  const jwk = await getJwks.getJwk({ domain, kid: key.kid })
+
+  t.ok(jwk)
+  t.deepEqual(jwk, key)
+})
+
 t.test('caches a successful response', async t => {
   nock(domain).get('/.well-known/jwks.json').once().reply(200, jwks)
 

--- a/test/getJwkDiscovery.spec.js
+++ b/test/getJwkDiscovery.spec.js
@@ -54,6 +54,18 @@ t.test('returns a jwk if alg and kid match for discovery', async t => {
   t.deepEqual(jwk, key)
 })
 
+t.test('returns a jwk if no alg is provided and kid match for discovery', async t => {
+  nock(domain).get('/.well-known/openid-configuration').reply(200, oidcConfig)
+  nock(domain).get('/.well-known/certs').reply(200, jwks)
+  const getJwks = buildGetJwks({ providerDiscovery: true })
+  const key = jwks.keys[2]
+
+  const jwk = await getJwks.getJwk({ domain, kid: key.kid })
+
+  t.ok(jwk)
+  t.deepEqual(jwk, key)
+})
+
 t.test('caches a successful response for discovery', async t => {
   nock(domain).get('/.well-known/openid-configuration').reply(200, oidcConfig)
   nock(domain).get('/.well-known/certs').reply(200, jwks)


### PR DESCRIPTION
As per the JSON Web Key specification (RFC 7517), the [alg parameter is optional](https://tools.ietf.org/html/rfc7517#section-4.4).

Some providers, for example Azure AD, don't provide the algorithm, so retrieveJwk always return errors.JWK_NOT_FOUND.

I've added a simple check for the property in the keys.find() filter.