### PR TITLE
feat: add specifyJwksPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ const getJwks = buildGetJwks({
 - `maxAge`: Milliseconds an item will remain in cache. Defaults to 60s.
 - `allowedDomains`: Array of allowed domains. By default all domains are allowed.
 - `providerDiscovery`: Indicates if the Provider Configuration Information is used to automatically get the jwks_uri from the [OpenID Provider Discovery Endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig). This endpoint is exposing the [Provider Metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata). With this flag set to true the domain will be treated as the OpenID Issuer which is the iss property in the token. Defaults to false
+- `specifyJwksPath`: Specify a relative path to the jwks_uri. Example `/otherdir/jwks.json`. Optional.
 
 > `max` and `maxAge` are provided to [lru-cache](https://www.npmjs.com/package/lru-cache).
 
@@ -40,7 +41,7 @@ const buildGetJwks = require('get-jwks')
 const getJwks = buildGetJwks()
 
 const jwk = await getJwks.getJwk({
-  domain: 'https://exampe.com/',
+  domain: 'https://example.com/',
   alg: 'token_alg',
   kid: 'token_kid',
 })

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ const getJwks = buildGetJwks({
 - `max`: Max items to hold in cache. Defaults to 100.
 - `maxAge`: Milliseconds an item will remain in cache. Defaults to 60s.
 - `allowedDomains`: Array of allowed domains. By default all domains are allowed.
-- `providerDiscovery`: Indicates if the Provider Configuration Information is used to automatically get the jwks_uri from the [OpenID Provider Discovery Endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig). This endpoint is exposing the [Provider Metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata). With this flag set to true the domain will be treated as the OpenID Issuer which is the iss property in the token. Defaults to false
-- `jwksPath`: Specify a relative path to the jwks_uri. Example `/otherdir/jwks.json`. Optional.
+- `providerDiscovery`: Indicates if the Provider Configuration Information is used to automatically get the jwks_uri from the [OpenID Provider Discovery Endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig). This endpoint is exposing the [Provider Metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata). With this flag set to true the domain will be treated as the OpenID Issuer which is the iss property in the token. Defaults to false. Ignored if jwksPath is specified.
+- `jwksPath`: Specify a relative path to the jwks_uri. Example `/otherdir/jwks.json`. Takes precedence over providerDiscovery. Optional.
 - `agent`: The custom agent to use for requests, as specified in [node-fetch documentation](https://github.com/node-fetch/node-fetch#custom-agent). Defaults to `null`.
 
 > `max` and `maxAge` are provided to [lru-cache](https://www.npmjs.com/package/lru-cache).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const getJwks = buildGetJwks({
 - `maxAge`: Milliseconds an item will remain in cache. Defaults to 60s.
 - `allowedDomains`: Array of allowed domains. By default all domains are allowed.
 - `providerDiscovery`: Indicates if the Provider Configuration Information is used to automatically get the jwks_uri from the [OpenID Provider Discovery Endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig). This endpoint is exposing the [Provider Metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata). With this flag set to true the domain will be treated as the OpenID Issuer which is the iss property in the token. Defaults to false
-- `specifyJwksPath`: Specify a relative path to the jwks_uri. Example `/otherdir/jwks.json`. Optional.
+- `jwksPath`: Specify a relative path to the jwks_uri. Example `/otherdir/jwks.json`. Optional.
 - `agent`: The custom agent to use for requests, as specified in [node-fetch documentation](https://github.com/node-fetch/node-fetch#custom-agent). Defaults to `null`.
 
 > `max` and `maxAge` are provided to [lru-cache](https://www.npmjs.com/package/lru-cache).

--- a/src/get-jwks.js
+++ b/src/get-jwks.js
@@ -24,8 +24,8 @@ function buildGetJwks(options = {}) {
   const maxAge = options.maxAge || 60 * 1000 /* 1 minute */
   const allowedDomains = (options.allowedDomains || []).map(ensureTrailingSlash)
   const providerDiscovery = options.providerDiscovery || false
-  const specifyJwksPath = options.specifyJwksPath
-    ? ensureNoLeadingSlash(options.specifyJwksPath)
+  const jwksPath = options.jwksPath
+    ? ensureNoLeadingSlash(options.jwksPath)
     : false
   const agent = options.agent || null
   const staleCache = new LRU({ max: max * 2, maxAge })
@@ -40,22 +40,22 @@ function buildGetJwks(options = {}) {
       `${normalizedDomain}.well-known/openid-configuration`,
       {
         agent,
-        timeout: 5000,        
+        timeout: 5000,
       }
     )
     const body = await response.json()
-  
+
     if (!response.ok) {
       const error = new Error(response.statusText)
       error.response = response
       error.body = body
       throw error
     }
-  
+
     if (!body.jwks_uri) {
       throw new Error(errors.NO_JWKS_URI)
     }
-  
+
     return body.jwks_uri
   }
 
@@ -99,8 +99,8 @@ function buildGetJwks(options = {}) {
   }
 
   async function retrieveJwk(normalizedDomain, alg, kid) {
-    const jwksUri = specifyJwksPath
-      ? `${normalizedDomain}${specifyJwksPath}`
+    const jwksUri = jwksPath
+      ? normalizedDomain + jwksPath
       : providerDiscovery
       ? await getJwksUri(normalizedDomain)
       : `${normalizedDomain}.well-known/jwks.json`

--- a/src/get-jwks.js
+++ b/src/get-jwks.js
@@ -19,29 +19,6 @@ function ensureNoLeadingSlash(path) {
   return path.startsWith('/') ? path.substring(1) : path
 }
 
-async function getJwksUri(normalizedDomain) {
-  const response = await fetch(
-    `${normalizedDomain}.well-known/openid-configuration`,
-    {
-      timeout: 5000,
-    }
-  )
-  const body = await response.json()
-
-  if (!response.ok) {
-    const error = new Error(response.statusText)
-    error.response = response
-    error.body = body
-    throw error
-  }
-
-  if (!body.jwks_uri) {
-    throw new Error(errors.NO_JWKS_URI)
-  }
-
-  return body.jwks_uri
-}
-
 function buildGetJwks(options = {}) {
   const max = options.max || 100
   const maxAge = options.maxAge || 60 * 1000 /* 1 minute */

--- a/test/getJwk.spec.js
+++ b/test/getJwk.spec.js
@@ -49,6 +49,21 @@ t.test('returns a jwk if alg and kid match', async t => {
   t.same(jwk, key)
 })
 
+t.test('returns a jwk if alg and kid match and path is specified', async t => {
+  nock(domain).get('/otherdir/jwks.json').reply(200, jwks)
+  const getJwks = buildGetJwks({ specifyJwksPath: '/otherdir/jwks.json' })
+  const key = jwks.keys[0]
+
+  const jwk = await getJwks.getJwk({
+    domain,
+    alg: key.alg,
+    kid: key.kid,
+  })
+
+  t.ok(jwk)
+  t.same(jwk, key)
+})
+
 t.test('returns a jwk if no alg is provided and kid match', async t => {
   nock(domain).get('/.well-known/jwks.json').reply(200, jwks)
   const getJwks = buildGetJwks()

--- a/test/getJwk.spec.js
+++ b/test/getJwk.spec.js
@@ -51,7 +51,7 @@ t.test('returns a jwk if alg and kid match', async t => {
 
 t.test('returns a jwk if alg and kid match and path is specified', async t => {
   nock(domain).get('/otherdir/jwks.json').reply(200, jwks)
-  const getJwks = buildGetJwks({ specifyJwksPath: '/otherdir/jwks.json' })
+  const getJwks = buildGetJwks({ jwksPath: '/otherdir/jwks.json' })
   const key = jwks.keys[0]
 
   const jwk = await getJwks.getJwk({

--- a/test/getJwk.spec.js
+++ b/test/getJwk.spec.js
@@ -131,6 +131,15 @@ t.test('supports domain without trailing slash', async t => {
   t.ok(key)
 })
 
+t.test('supports path without leading slash', async t => {
+  nock(domain).get('/otherdir/jwks.json').reply(200, jwks)
+  const getJwks = buildGetJwks({ jwksPath: 'otherdir/jwks.json' })
+  const [{ alg, kid }] = jwks.keys
+
+  const key = await getJwks.getJwk({ domain: 'https://localhost', alg, kid })
+  t.ok(key)
+})
+
 t.test('does not execute concurrent requests', () => {
   nock(domain).get('/.well-known/jwks.json').once().reply(200, jwks)
 


### PR DESCRIPTION
Adds optional specifyJwksPath into options for specifying relative path. Takes precedence over discovery on same domain. Works with or without leading /