### PR TITLE
Typed agent property correctly, addressing #137

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/nearform/get-jwks#readme",
   "dependencies": {
+    "@types/node": "^17.0.35",
     "jwk-to-pem": "^2.0.4",
     "lru-cache": "^7.4.0",
     "node-fetch": "^2.6.1"

--- a/src/get-jwks.d.ts
+++ b/src/get-jwks.d.ts
@@ -1,4 +1,5 @@
 import LRU from 'lru-cache'
+import type { Agent } from 'https'
 
 type JWKSignature = { domain: string; alg: string; kid: string }
 type JWK = { [key: string]: any; domain: string; alg: string; kid: string }
@@ -15,7 +16,7 @@ type GetJwksOptions = {
   allowedDomains?: string[]
   providerDiscovery?: boolean
   jwksPath?: string
-  agent?: string
+  agent?: Agent
 }
 
 type GetJwks = {


### PR DESCRIPTION
The `agent` config property was mistyped as an optional `string`. Now it's not :)

Fixes #137