### PR TITLE
fix(get-jwks): make `alg` optional

### DIFF
--- a/src/get-jwks.js
+++ b/src/get-jwks.js
@@ -120,7 +120,9 @@ function buildGetJwks(options = {}) {
     }
 
     const jwk = body.keys.find(
-      key => (alg === undefined || key.alg === undefined || key.alg === alg) && key.kid === kid
+      key =>
+        (alg === undefined || key.alg === undefined || key.alg === alg) &&
+        key.kid === kid
     )
 
     if (!jwk) {

--- a/src/get-jwks.js
+++ b/src/get-jwks.js
@@ -120,7 +120,7 @@ function buildGetJwks(options = {}) {
     }
 
     const jwk = body.keys.find(
-      key => (key.alg === undefined || key.alg === alg) && key.kid === kid
+      key => (alg === undefined || key.alg === undefined || key.alg === alg) && key.kid === kid
     )
 
     if (!jwk) {

--- a/test/getJwk.spec.js
+++ b/test/getJwk.spec.js
@@ -75,6 +75,17 @@ t.test('returns a jwk if no alg is provided and kid match', async t => {
   t.same(jwk, key)
 })
 
+t.test('returns a jwk if no alg is provided and kid match but jwk has alg', async t => {
+  nock(domain).get('/.well-known/jwks.json').reply(200, jwks)
+  const getJwks = buildGetJwks()
+  const key = jwks.keys[1]
+
+  const jwk = await getJwks.getJwk({ domain, kid: key.kid })
+
+  t.ok(jwk)
+  t.same(jwk, key)
+})
+
 t.test('caches a successful response', async t => {
   nock(domain).get('/.well-known/jwks.json').once().reply(200, jwks)
 

--- a/test/getJwk.spec.js
+++ b/test/getJwk.spec.js
@@ -75,16 +75,19 @@ t.test('returns a jwk if no alg is provided and kid match', async t => {
   t.same(jwk, key)
 })
 
-t.test('returns a jwk if no alg is provided and kid match but jwk has alg', async t => {
-  nock(domain).get('/.well-known/jwks.json').reply(200, jwks)
-  const getJwks = buildGetJwks()
-  const key = jwks.keys[1]
+t.test(
+  'returns a jwk if no alg is provided and kid match but jwk has alg',
+  async t => {
+    nock(domain).get('/.well-known/jwks.json').reply(200, jwks)
+    const getJwks = buildGetJwks()
+    const key = jwks.keys[1]
 
-  const jwk = await getJwks.getJwk({ domain, kid: key.kid })
+    const jwk = await getJwks.getJwk({ domain, kid: key.kid })
 
-  t.ok(jwk)
-  t.same(jwk, key)
-})
+    t.ok(jwk)
+    t.same(jwk, key)
+  }
+)
 
 t.test('caches a successful response', async t => {
   nock(domain).get('/.well-known/jwks.json').once().reply(200, jwks)

--- a/test/getJwkDiscovery.spec.js
+++ b/test/getJwkDiscovery.spec.js
@@ -66,6 +66,18 @@ t.test('returns a jwk if no alg is provided and kid match for discovery', async 
   t.same(jwk, key)
 })
 
+t.test('returns a jwk if no alg is provided and kid match for discovery but jwk has alg', async t => {
+  nock(domain).get('/.well-known/openid-configuration').reply(200, oidcConfig)
+  nock(domain).get('/.well-known/certs').reply(200, jwks)
+  const getJwks = buildGetJwks({ providerDiscovery: true })
+  const key = jwks.keys[1]
+
+  const jwk = await getJwks.getJwk({ domain, kid: key.kid })
+
+  t.ok(jwk)
+  t.same(jwk, key)
+})
+
 t.test('caches a successful response for discovery', async t => {
   nock(domain).get('/.well-known/openid-configuration').reply(200, oidcConfig)
   nock(domain).get('/.well-known/certs').reply(200, jwks)

--- a/test/getJwkDiscovery.spec.js
+++ b/test/getJwkDiscovery.spec.js
@@ -54,29 +54,35 @@ t.test('returns a jwk if alg and kid match for discovery', async t => {
   t.same(jwk, key)
 })
 
-t.test('returns a jwk if no alg is provided and kid match for discovery', async t => {
-  nock(domain).get('/.well-known/openid-configuration').reply(200, oidcConfig)
-  nock(domain).get('/.well-known/certs').reply(200, jwks)
-  const getJwks = buildGetJwks({ providerDiscovery: true })
-  const key = jwks.keys[2]
+t.test(
+  'returns a jwk if no alg is provided and kid match for discovery',
+  async t => {
+    nock(domain).get('/.well-known/openid-configuration').reply(200, oidcConfig)
+    nock(domain).get('/.well-known/certs').reply(200, jwks)
+    const getJwks = buildGetJwks({ providerDiscovery: true })
+    const key = jwks.keys[2]
 
-  const jwk = await getJwks.getJwk({ domain, kid: key.kid })
+    const jwk = await getJwks.getJwk({ domain, kid: key.kid })
 
-  t.ok(jwk)
-  t.same(jwk, key)
-})
+    t.ok(jwk)
+    t.same(jwk, key)
+  }
+)
 
-t.test('returns a jwk if no alg is provided and kid match for discovery but jwk has alg', async t => {
-  nock(domain).get('/.well-known/openid-configuration').reply(200, oidcConfig)
-  nock(domain).get('/.well-known/certs').reply(200, jwks)
-  const getJwks = buildGetJwks({ providerDiscovery: true })
-  const key = jwks.keys[1]
+t.test(
+  'returns a jwk if no alg is provided and kid match for discovery but jwk has alg',
+  async t => {
+    nock(domain).get('/.well-known/openid-configuration').reply(200, oidcConfig)
+    nock(domain).get('/.well-known/certs').reply(200, jwks)
+    const getJwks = buildGetJwks({ providerDiscovery: true })
+    const key = jwks.keys[1]
 
-  const jwk = await getJwks.getJwk({ domain, kid: key.kid })
+    const jwk = await getJwks.getJwk({ domain, kid: key.kid })
 
-  t.ok(jwk)
-  t.same(jwk, key)
-})
+    t.ok(jwk)
+    t.same(jwk, key)
+  }
+)
 
 t.test('caches a successful response for discovery', async t => {
   nock(domain).get('/.well-known/openid-configuration').reply(200, oidcConfig)


### PR DESCRIPTION
The [documentation states](https://github.com/nearform/get-jwks#getjwk) that `alg` is optional, however if `alg` is undefined then both `getjwk()` and `getpublickey()` will throw "No matching JWK found in the set.".

This PR updates the conditional when searching the retrieved JWKS to allow for the `alg` to be undefined, and only match on the `kid`.