### PR TITLE
build(deps): move @types/node to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "https://github.com/nearform/get-jwks#readme",
   "dependencies": {
-    "@types/node": "^18.0.0",
     "jwk-to-pem": "^2.0.4",
     "lru-cache": "^7.4.0",
     "node-fetch": "^2.6.1"
@@ -37,6 +36,7 @@
   "devDependencies": {
     "@fastify/jwt": "^6.1.0",
     "@types/lru-cache": "^7.4.0",
+    "@types/node": "^18.6.5",
     "eslint": "^8.6.0",
     "fast-jwt": "^1.1.2",
     "fastify": "^4.0.3",


### PR DESCRIPTION
Not required as a production dependency, and others repos don't use it as such either, see [nearform/fast-jwt's package.json for example](https://github.com/nearform/fast-jwt/blob/master/package.json).
Should reduce production installs of this module by ~1.6mb (which is around 10% of node_modules size for my repos that use this module).