### PR TITLE
feat(get-jwks): add code to thrown error (#156)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "devDependencies": {
     "@fastify/jwt": "^6.1.0",
-    "@types/lru-cache": "^7.4.0",
     "@types/node": "^18.6.5",
+    "@types/node-fetch": "^2.6.2",
     "eslint": "^8.6.0",
     "fast-jwt": "^1.1.2",
     "fastify": "^4.0.3",

--- a/src/error.d.ts
+++ b/src/error.d.ts
@@ -1,0 +1,21 @@
+import type { Response } from 'node-fetch'
+
+export enum errorCode {
+  OPENID_CONFIGURATION_REQUEST_FAILED = 'OPENID_CONFIGURATION_REQUEST_FAILED',
+  JWKS_REQUEST_FAILED = 'JWKS_REQUEST_FAILED',
+  NO_JWKS_URI = 'NO_JWKS_URI',
+  NO_JWKS = 'NO_JWKS',
+  JWK_NOT_FOUND = 'JWK_NOT_FOUND',
+  DOMAIN_NOT_ALLOWED = 'DOMAIN_NOT_ALLOWED',
+}
+
+declare class GetJwksError extends Error {
+  code: errorCode
+  response: Response
+  body: unknown
+
+  constructor(
+    code: errorCode,
+    requestProperties?: { response: Response; body: unknown }
+  )
+}

--- a/src/error.js
+++ b/src/error.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const errorCode = {
+  OPENID_CONFIGURATION_REQUEST_FAILED: 'OPENID_CONFIGURATION_REQUEST_FAILED',
+  JWKS_REQUEST_FAILED: 'JWKS_REQUEST_FAILED',
+  NO_JWKS_URI: 'NO_JWKS_URI',
+  NO_JWKS: 'NO_JWKS',
+  JWK_NOT_FOUND: 'JWK_NOT_FOUND',
+  DOMAIN_NOT_ALLOWED: 'DOMAIN_NOT_ALLOWED',
+}
+
+const errors = {
+  [errorCode.OPENID_CONFIGURATION_REQUEST_FAILED]:
+    'OpenID configuration request failed',
+  [errorCode.JWKS_REQUEST_FAILED]: 'JWKS request failed',
+  [errorCode.NO_JWKS_URI]: 'No valid jwks_uri key found in providerConfig',
+  [errorCode.NO_JWKS]: 'No JWKS found in the response.',
+  [errorCode.JWK_NOT_FOUND]: 'No matching JWK found in the set.',
+  [errorCode.DOMAIN_NOT_ALLOWED]: 'The domain is not allowed.',
+}
+
+class GetJwksError extends Error {
+  constructor(code, requestProperties = {}) {
+    super(errors[code])
+
+    this.name = GetJwksError.name
+    this.code = code
+
+    this.response = requestProperties.response
+    this.body = requestProperties.body
+  }
+}
+
+module.exports = {
+  errorCode,
+  GetJwksError,
+}

--- a/test/getJwk.spec.js
+++ b/test/getJwk.spec.js
@@ -5,6 +5,7 @@ const t = require('tap')
 
 const { jwks, domain } = require('./constants')
 const buildGetJwks = require('../src/get-jwks')
+const { GetJwksError, errorCode } = require('../src/error')
 
 t.beforeEach(async () => {
   nock.disableNetConnect()
@@ -21,8 +22,11 @@ t.test('rejects if the request fails', async t => {
   const [{ alg, kid }] = jwks.keys
   const getJwks = buildGetJwks()
 
-  const expectedError = new Error('Internal Server Error')
-  expectedError.body = { msg: 'boom' }
+  const expectedError = {
+    name: GetJwksError.name,
+    code: errorCode.JWKS_REQUEST_FAILED,
+    body: { msg: 'boom' },
+  }
 
   await t.rejects(getJwks.getJwk({ domain, alg, kid }), expectedError)
 })

--- a/test/getJwkDiscovery.spec.js
+++ b/test/getJwkDiscovery.spec.js
@@ -5,6 +5,7 @@ const t = require('tap')
 
 const { oidcConfig, jwks, domain } = require('./constants')
 const buildGetJwks = require('../src/get-jwks')
+const { errorCode, GetJwksError } = require('../src/error')
 
 t.beforeEach(async () => {
   nock.disableNetConnect()
@@ -23,9 +24,11 @@ t.test('rejects if the discovery request fails', async t => {
   const [{ alg, kid }] = jwks.keys
   const getJwks = buildGetJwks({ providerDiscovery: true })
 
-  const expectedError = new Error('Internal Server Error')
-  expectedError.body = { msg: 'baam' }
-
+  const expectedError = {
+    name: GetJwksError.name,
+    code: errorCode.OPENID_CONFIGURATION_REQUEST_FAILED,
+    body: { msg: 'baam' },
+  }
   await t.rejects(getJwks.getJwk({ domain, alg, kid }), expectedError)
 })
 
@@ -36,7 +39,11 @@ t.test('rejects if the request fails', async t => {
   const [{ alg, kid }] = jwks.keys
   const getJwks = buildGetJwks({ providerDiscovery: true })
 
-  const expectedError = new Error('Internal Server Error')
+  const expectedError = {
+    name: GetJwksError.name,
+    code: errorCode.JWKS_REQUEST_FAILED,
+    body: { msg: 'boom' },
+  }
   expectedError.body = { msg: 'boom' }
 
   await t.rejects(getJwks.getJwk({ domain, alg, kid }), expectedError)

--- a/test/getJwksUri.spec.js
+++ b/test/getJwksUri.spec.js
@@ -6,6 +6,7 @@ const nock = require('nock')
 const { domain } = require('./constants')
 
 const buildGetJwks = require('../src/get-jwks')
+const { GetJwksError, errorCode } = require('../src/error')
 
 t.beforeEach(async () => {
   nock.disableNetConnect()
@@ -22,7 +23,11 @@ t.test('throw error if the discovery request fails', async t => {
     .reply(500, { msg: 'baam' })
   const getJwks = buildGetJwks({ providerDiscovery: true })
 
-  const expectedError = new Error('Internal Server Error')
+  const expectedError = {
+    name: GetJwksError.name,
+    code: errorCode.OPENID_CONFIGURATION_REQUEST_FAILED,
+    body: { msg: 'baam' },
+  }
 
   await t.rejects(getJwks.getJwksUri(domain), expectedError)
 })
@@ -35,9 +40,10 @@ t.test(
       .reply(200, { msg: 'baam' })
     const getJwks = buildGetJwks({ providerDiscovery: true })
 
-    const expectedError = new Error(
-      'No valid jwks_uri key found in providerConfig'
-    )
+    const expectedError = {
+      name: GetJwksError.name,
+      code: errorCode.NO_JWKS_URI,
+    }
 
     await t.rejects(getJwks.getJwksUri(domain), expectedError)
   }


### PR DESCRIPTION
It's been quite a while since I wrote vanilla JavaScript, so please feel free to suggest improvements.

I'm not really happy with the tests, I didn't see a way with tap to assert the class of an error and only do a partial match of its properties. Suggestions are welcome!

Closes #156 