### PR TITLE
chore: enabling npm provenance integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: nearform-actions/optic-release-automation-action@v4
@@ -32,3 +33,4 @@ jobs:
             ${{ secrets[format('OPTIC_TOKEN_{0}', github.actor)] ||
             secrets.OPTIC_TOKEN }}
           semver: ${{ github.event.inputs.semver }}
+          provenance: true


### PR DESCRIPTION
- Resolves #206  
- Enabling NPM Provenance beta integration when publishing new versions to NPM.
- Resolves partially https://github.com/nearform/hub-draft-issues/issues/247