### PR TITLE
fix: add files property to restrict files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Fetch utils for JWKS keys",
   "main": "src/get-jwks.js",
   "types": "./src/get-jwks.d.ts",
+  "files": [
+    "src"
+  ],
   "engines": {
     "node": ">=14"
   },


### PR DESCRIPTION
# Adds files property to package.json

Addresses https://github.com/nearform/get-jwks/issues/213
This change adds a files property to package.json to restrict the files added to the published npm package/tar.
