### PR TITLE
feat: Add user defined domain validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ const getJwks = buildGetJwks({
   ttl: 60 * 1000,
   timeout: 5000,
   allowedDomains: ['https://example.com'],
+  checkIssuer: (domain) => {
+    return domain === 'https://example.com'
+  },
   providerDiscovery: false,
   agent: new https.Agent({
     keepAlive: true,
@@ -34,6 +37,7 @@ const getJwks = buildGetJwks({
 - `ttl`: Milliseconds an item will remain in cache. Defaults to 60s.
 - `timeout`: Specifies how long it should wait to retrieve a JWK before it fails. The time is set in milliseconds. Defaults to 5s.
 - `allowedDomains`: Array of allowed domains. By default all domains are allowed.
+-  `checkIssuer`: Optional user defined function to validate a token's domain
 - `providerDiscovery`: Indicates if the Provider Configuration Information is used to automatically get the jwks_uri from the [OpenID Provider Discovery Endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig). This endpoint is exposing the [Provider Metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata). With this flag set to true the domain will be treated as the OpenID Issuer which is the iss property in the token. Defaults to false. Ignored if jwksPath is specified.
 - `jwksPath`: Specify a relative path to the jwks_uri. Example `/otherdir/jwks.json`. Takes precedence over providerDiscovery. Optional.
 - `agent`: The custom agent to use for requests, as specified in [node-fetch documentation](https://github.com/node-fetch/node-fetch#custom-agent). Defaults to `null`.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ const getJwks = buildGetJwks({
   ttl: 60 * 1000,
   timeout: 5000,
   allowedDomains: ['https://example.com'],
-  checkIssuer: (domain) => {
-    return domain === 'https://example.com'
+  checkIssuer: (issuer) => {
+    return issuer === 'https://example.com'
   },
   providerDiscovery: false,
   agent: new https.Agent({

--- a/src/get-jwks.js
+++ b/src/get-jwks.js
@@ -63,8 +63,10 @@ function buildGetJwks(options = {}) {
     const { domain, alg, kid } = signature
 
     const normalizedDomain = ensureTrailingSlash(domain)
+    const url = new URL(normalizedDomain)
+    const baseUrl = `${url.protocol}//${url.hostname}/`
 
-    if (allowedDomains.length && !allowedDomains.includes(normalizedDomain)) {
+    if (allowedDomains.length && !allowedDomains.includes(baseUrl)) {
       const error = new GetJwksError(errorCode.DOMAIN_NOT_ALLOWED)
       return Promise.reject(error)
     }

--- a/src/get-jwks.js
+++ b/src/get-jwks.js
@@ -63,10 +63,8 @@ function buildGetJwks(options = {}) {
     const { domain, alg, kid } = signature
 
     const normalizedDomain = ensureTrailingSlash(domain)
-    const url = new URL(normalizedDomain)
-    const baseUrl = `${url.protocol}//${url.hostname}/`
 
-    if (allowedDomains.length && !allowedDomains.includes(baseUrl)) {
+    if (allowedDomains.length && !allowedDomains.includes(normalizedDomain)) {
       const error = new GetJwksError(errorCode.DOMAIN_NOT_ALLOWED)
       return Promise.reject(error)
     }

--- a/src/get-jwks.js
+++ b/src/get-jwks.js
@@ -19,6 +19,7 @@ function buildGetJwks(options = {}) {
   const ttl = options.ttl || 60 * 1000 /* 1 minute */
   const timeout = options.timeout || 5 * 1000 /* 5 seconds */
   const allowedDomains = (options.allowedDomains || []).map(ensureTrailingSlash)
+  const checkIssuer = options.checkIssuer
   const providerDiscovery = options.providerDiscovery || false
   const jwksPath = options.jwksPath
     ? ensureNoLeadingSlash(options.jwksPath)
@@ -65,6 +66,11 @@ function buildGetJwks(options = {}) {
     const normalizedDomain = ensureTrailingSlash(domain)
 
     if (allowedDomains.length && !allowedDomains.includes(normalizedDomain)) {
+      const error = new GetJwksError(errorCode.DOMAIN_NOT_ALLOWED)
+      return Promise.reject(error)
+    }
+
+    if (checkIssuer && !checkIssuer(normalizedDomain)) {
       const error = new GetJwksError(errorCode.DOMAIN_NOT_ALLOWED)
       return Promise.reject(error)
     }


### PR DESCRIPTION
Relates to #226 

Adds support for an optional function to validate a token's domain when allowedDomains functionality does not suffice.