### PR TITLE
test: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install get-jwks
 ### Options
 
 ```js
-const https = require('https')
+const https = require('node:https')
 const buildGetJwks = require('get-jwks')
 
 const getJwks = buildGetJwks({

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const { readFileSync } = require('fs')
-const path = require('path')
+const { readFileSync } = require('node:fs')
+const path = require('node:path')
 const jwt = require('jsonwebtoken')
 
 const domain = 'https://localhost/'


### PR DESCRIPTION
Allows redundant `require.cache` calls to be bypassed for builtin modules, saving a few yoctoseconds.

See https://nodejs.org/api/modules.html#core-modules and [discussion in nodejs/node repo regarding why `require.cache` calls are redundant for builtins](https://github.com/nodejs/node/pull/37246/files#r588397158).