### PR TITLE
chore(package): explicitly declare js module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "9.0.0",
   "description": "Fetch utils for JWKS keys",
   "main": "src/get-jwks.js",
+  "type": "commonjs",
   "types": "./src/get-jwks.d.ts",
   "files": [
     "src"


### PR DESCRIPTION
[Node 21.1.0 added a flag to detect module types](https://github.com/nodejs/node/releases/tag/v21.1.0), which will probably become default in the future. Declaring the type will cause Node to skip detection on startup/compile, reducing startup time.

Declaring the package type is also considered good practice according to https://nodejs.org/api/modules.html#enabling.