### PR TITLE
fix: update types to work with ESM + TS

### DIFF
--- a/src/get-jwks.d.ts
+++ b/src/get-jwks.d.ts
@@ -1,16 +1,24 @@
 import type { LRUCache } from 'lru-cache'
 import type { Agent } from 'https'
 
-export type JWKSignature = { domain: string; alg: string; kid: string }
-export type JWK = { [key: string]: any; domain: string; alg: string; kid: string }
-
-export type GetPublicKeyOptions = {
+type GetPublicKeyOptions = {
   domain?: string
   alg?: string
   kid?: string
 }
 
-export type GetJwksOptions = {
+type JWKSignature = { domain: string; alg: string; kid: string }
+type JWK = { [key: string]: any; domain: string; alg: string; kid: string }
+
+type GetJwks = {
+  getPublicKey: (options?: GetPublicKeyOptions) => Promise<string>
+  getJwk: (signature: JWKSignature) => Promise<JWK>
+  getJwksUri: (normalizedDomain: string) => Promise<string>
+  cache: LRUCache<string, JWK>
+  staleCache: LRUCache<string, JWK>
+}
+
+type GetJwksOptions = {
   max?: number
   ttl?: number
   issuersWhitelist?: string[]
@@ -20,12 +28,9 @@ export type GetJwksOptions = {
   timeout?: number
 }
 
-export type GetJwks = {
-  getPublicKey: (options?: GetPublicKeyOptions) => Promise<string>
-  getJwk: (signature: JWKSignature) => Promise<JWK>
-  getJwksUri: (normalizedDomain: string) => Promise<string>
-  cache: LRUCache<string, JWK>
-  staleCache: LRUCache<string, JWK>
+declare namespace buildGetJwks {
+  export type { JWKSignature, JWK, GetPublicKeyOptions, GetJwksOptions, GetJwks }
 }
 
-export default function buildGetJwks(options?: GetJwksOptions): GetJwks
+declare function buildGetJwks(options?: GetJwksOptions): GetJwks
+export = buildGetJwks


### PR DESCRIPTION
Addresses [242](https://github.com/nearform/get-jwks/issues/242)

Adds a namespace and declares `buildGetJwks` so ESM + TS works.

I'm not sure how to write tests for this issue because it requires changing `package.json` to use ESM. See https://github.com/jmjf/get-jwks-demo README for how to demonstrate the issue and how to prove the fix works. LMK if you know of a better testing approach.

I chose to declare all types, then export them in the namespace, as described in the README. Alternatively, I could export the types in the namespace and change `declare function buildGetJwks...` as described in the README if you prefer.