### PR TITLE
Upgrade jwk-to-pem to v.2.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-jwks",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "Fetch utils for JWKS keys",
   "main": "src/get-jwks.js",
   "types": "./src/get-jwks.d.ts",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/nearform/get-jwks#readme",
   "dependencies": {
-    "jwk-to-pem": "^2.0.4",
+    "jwk-to-pem": "^2.0.6",
     "lru-cache": "^11.0.0",
     "node-fetch": "^2.6.1"
   },


### PR DESCRIPTION
Update `jwk-to-pem` to v.2.0.6 which addresses a critical security vulnerability with `elliptic` peer dependency
![image](https://github.com/user-attachments/assets/6b222f8c-26ec-41a6-9369-a55d5245b216)

Fixes #304 