### PR TITLE
chore!: drop Node.js less than 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,22 +6,10 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version:
-          - 14
-          - 16
-          - 18
-          - 20
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm i
-      - run: npm run lint
-      - run: npm run test
+    uses: pkgjs/action/.github/workflows/node-test.yaml@v0
+    with:
+      strategy-fail-fast: true
+      test-command: npm run lint && npm run test
   automerge:
     needs: build
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=14"
+    "node": ">=20"
   },
   "tsd": {
     "directory": "./test/types"


### PR DESCRIPTION
Also, switch to using pkgjs action in CI workflow to handle Node.js versions.

Addresses https://github.com/nearform/get-jwks/issues/309

BREAKING CHANGE: this will drop support for Node.js < 20