### PR TITLE
fix: Remove `undici` package and use RequestInit global interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "prettier": "^3.5.3",
     "sinon": "^21.0.0",
     "tsd": "^0.33.0",
-    "typescript": "^5.8.3",
-    "undici": "~7.16.0"
+    "typescript": "^5.8.3"
   }
 }

--- a/src/get-jwks.d.ts
+++ b/src/get-jwks.d.ts
@@ -1,4 +1,5 @@
 import Cache from './cache';
+import * as undici from "undici-types";
 
 type GetPublicKeyOptions = {
   domain?: string
@@ -23,7 +24,7 @@ type GetJwksOptions = {
   issuersWhitelist?: string[]
   providerDiscovery?: boolean
   jwksPath?: string
-  fetchOptions?: import("undici").RequestInit
+  fetchOptions?: undici.RequestInit
 }
 
 declare namespace buildGetJwks {

--- a/test/types/get-jwks.test-d.ts
+++ b/test/types/get-jwks.test-d.ts
@@ -1,7 +1,7 @@
 import { expectAssignable } from 'tsd'
-import { getGlobalDispatcher } from 'undici'
 import Cache from '../../src/cache'
 import buildGetJwks, { GetJwksOptions, GetPublicKeyOptions, JWK, JWKSignature } from '../../src/get-jwks'
+import * as undici from "undici-types";
 
 const { getPublicKey, getJwk, getJwksUri, cache, staleCache } = buildGetJwks()
 
@@ -11,5 +11,5 @@ expectAssignable<(options?: GetPublicKeyOptions) => Promise<string>>(getPublicKe
 expectAssignable<Cache<string, JWK>>(cache)
 expectAssignable<Cache<string, JWK>>(staleCache)
 expectAssignable<GetJwksOptions['fetchOptions']>({
-    dispatcher: getGlobalDispatcher()
+    dispatcher: undici.getGlobalDispatcher()
 })


### PR DESCRIPTION
fixes #368 